### PR TITLE
Added support for karma testing.

### DIFF
--- a/GruntFile.js
+++ b/GruntFile.js
@@ -3,6 +3,8 @@ module.exports = function(grunt) {
 	grunt.loadNpmTasks('grunt-contrib-watch');
 	grunt.loadNpmTasks('grunt-contrib-concat');
 	grunt.loadNpmTasks('grunt-contrib-uglify');
+	grunt.loadNpmTasks('grunt-contrib-jshint');
+	grunt.loadNpmTasks('grunt-karma');
 
 	grunt.initConfig({
 		pkg: grunt.file.readJSON('package.json'),
@@ -43,7 +45,26 @@ module.exports = function(grunt) {
 				],
 				tasks:['concat', 'uglify']
 			}
-		}
+		},
+		karma: {
+  			unit: {
+    			configFile: 'karma.conf.js',
+    			runnerPort: 9999,
+    			singleRun: true,
+    			background: false,
+    			browsers: ['PhantomJS']
+  			}
+		},
+		jshint: {
+	    	allFiles: [
+	        	'Gruntfile.js',
+	        	'src/*.js',
+	        	'libs/*.js'
+	      	],
+	      	options: {
+	        	jshintrc: '.jshintrc'
+	      	}
+	    }
 	});
 
 	grunt.registerTask('default', ['concat', 'uglify']);

--- a/karma.conf.js
+++ b/karma.conf.js
@@ -1,0 +1,73 @@
+// base path, that will be used to resolve files and exclude
+basePath = './';
+
+// list of files / patterns to load in the browser
+files = [
+ 	JASMINE,
+ 	JASMINE_ADAPTER,
+ 	'build/soma.js',
+  	'tests/spec/*.js'
+];
+
+// list of files to exclude
+exclude = [
+];
+
+// use dots reporter, as travis terminal does not support escaping sequences
+// possible values: 'dots', 'progress', 'junit', 'teamcity'
+// CLI --reporters progress
+reporters = ['progress'];
+
+junitReporter = {
+  // will be resolved to basePath (in the same way as files/exclude patterns)
+  // outputFile: 'test-results.xml'
+};
+
+// web server port
+// CLI --port 9876
+port = 9876;
+
+// cli runner port
+// CLI --runner-port 9100
+runnerPort = 9100;
+
+// enable / disable colors in the output (reporters and logs)
+// CLI --colors --no-colors
+colors = true;
+
+// level of logging
+// possible values: LOG_DISABLE || LOG_ERROR || LOG_WARN || LOG_INFO || LOG_DEBUG
+// CLI --log-level debug
+logLevel = LOG_INFO;
+
+// enable / disable watching file and executing tests whenever any file changes
+// CLI --auto-watch --no-auto-watch
+autoWatch = true;
+
+// Start these browsers, currently available:
+// - Chrome
+// - ChromeCanary
+// - Firefox
+// - Opera
+// - Safari (only Mac)
+// - PhantomJS
+// - IE (only Windows)
+// CLI --browsers Chrome,Firefox,Safari
+browsers = [];
+
+// If browser does not capture in given timeout [ms], kill it
+// CLI --capture-timeout 5000
+captureTimeout = 5000;
+
+// Auto run tests on start (when browsers are captured) and exit
+// CLI --single-run --no-single-run
+singleRun = false;
+
+// report which specs are slower than 500ms
+// CLI --report-slower-than 500
+reportSlowerThan = 500;
+
+// compile coffee scripts
+preprocessors = {
+  '**/*.coffee': 'coffee'
+};

--- a/package.json
+++ b/package.json
@@ -1,31 +1,33 @@
 {
-	"name":"soma.js",
-	"version":"2.0.4",
-	"description":"soma.js is a javascript framework created to build scalable and maintainable applications.",
-	"keywords": [
-		"soma.js",
-		"soma",
-		"javascript",
-		"js",
-		"framework",
-		"mvc",
-		"lightweight",
-		"dependency injection",
-		"injection"
-	],
-	"author":{
-		"name":"Romuald Quantin",
-		"email":"romu@soundstep.com"
-	},
-	"main": "build/soma.js",
-	"repository": {
-		"type": "git",
-		"url": "https://github.com/somajs/somajs.git"
-	},
-	"devDependencies": {
-		"grunt": ">=0.4.x",
-		"grunt-contrib-watch": "*",
-		"grunt-contrib-concat": "*",
-		"grunt-contrib-uglify": "*"
-	}
+  "name": "soma.js",
+  "version": "2.0.4",
+  "description": "soma.js is a javascript framework created to build scalable and maintainable applications.",
+  "keywords": [
+    "soma.js",
+    "soma",
+    "javascript",
+    "js",
+    "framework",
+    "mvc",
+    "lightweight",
+    "dependency injection",
+    "injection"
+  ],
+  "author": {
+    "name": "Romuald Quantin",
+    "email": "romu@soundstep.com"
+  },
+  "main": "build/soma.js",
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/somajs/somajs.git"
+  },
+  "devDependencies": {
+    "grunt": ">=0.4.x",
+    "grunt-contrib-watch": "*",
+    "grunt-contrib-concat": "*",
+    "grunt-contrib-uglify": "*",
+    "grunt-karma": "~0.4.5",
+    "grunt-contrib-jshint": "~0.6.0"
+  }
 }


### PR DESCRIPTION
EDIT: I had to close the previous pull request, some commits got messed up, but this one is clean and nice.
Now we can execute tests "headlessly" using grunt and karma. Just run "grunt karma" and the results will be displayed into the console. It uses PhantomJS in the background. There is a known issue of karma not being able to run test cases on PhantomJS (karma-runner/karma#558), currently it is working for me, and my setup is Mac OS X 10.8.4, node 0.10.13 and karma 0.8.7.
Also I've added a grunt task for jshinting the javascript files.
